### PR TITLE
Protobuf's url changed

### DIFF
--- a/Client.go
+++ b/Client.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net"
 
-	"code.google.com/p/gogoprotobuf/proto"
+	"github.com/gogo/protobuf"
 
 	"github.com/ninjasphere/go-castv2/api"
 )

--- a/api/cast_channel.pb.go
+++ b/api/cast_channel.pb.go
@@ -17,7 +17,7 @@ It has these top-level messages:
 */
 package api
 
-import proto "code.google.com/p/gogoprotobuf/proto"
+import proto "github.com/gogo/protobuf"
 import json "encoding/json"
 import math "math"
 


### PR DESCRIPTION
They archived their google code project, so the url changed from code.google.com/p/gogoprotobuf/proto to github.com/gogo/protobuf.
